### PR TITLE
Simplify filetype computation

### DIFF
--- a/gap/splash_from_Viz.g
+++ b/gap/splash_from_Viz.g
@@ -101,13 +101,7 @@ if not IsBound(Splash) then
     if IsBound(opt.filetype) then
       filetype := opt.filetype;
     else
-       if ARCH_IS_UNIX( ) then
-        filetype := "pdf";
-      elif ARCH_IS_WINDOWS( ) then
-       filetype := "pdf";
-      elif ARCH_IS_MAC_OS_X( ) then
-        filetype := "svg";
-      fi;
+      filetype := "pdf";
     fi;  
     ######################
     if tikz or dotstring{[1..5]}="%tikz" then


### PR DESCRIPTION
The implementation of `ARCH_IS_UNIX` is `not ARCH_IS_WINDOWS`,
hence the `ARCH_IS_MAC_OS_X` branch could never be reached.
