### PR TITLE
Remove superfluous .release script

### DIFF
--- a/.release
+++ b/.release
@@ -1,4 +1,0 @@
-#!/bin/sh
-# This file is executed by the `release` script from
-# https://github.com/gap-system/ReleaseTools
-rm -rf .codecov.yml


### PR DESCRIPTION
Latest ReleaseTools deletes .codecov.yml by itself
