### PR TITLE
Switch to two argument version of ReadPackage

### DIFF
--- a/init.g
+++ b/init.g
@@ -1,11 +1,11 @@
-ReadPackage("intpic/gap/ip_display.gd");
-ReadPackage("intpic/gap/ip_colors.gd");
-ReadPackage("intpic/gap/ip_options.gd");
-ReadPackage("intpic/gap/ip_tikz.gd");
-ReadPackage("intpic/gap/ip_dot.gd");
-ReadPackage("intpic/gap/ip_utils.gd");
-ReadPackage("intpic/gap/ip_tables.gd");
-ReadPackage("intpic/gap/ip_routines_for_NS.gd");
+ReadPackage("intpic", "gap/ip_display.gd");
+ReadPackage("intpic", "gap/ip_colors.gd");
+ReadPackage("intpic", "gap/ip_options.gd");
+ReadPackage("intpic", "gap/ip_tikz.gd");
+ReadPackage("intpic", "gap/ip_dot.gd");
+ReadPackage("intpic", "gap/ip_utils.gd");
+ReadPackage("intpic", "gap/ip_tables.gd");
+ReadPackage("intpic", "gap/ip_routines_for_NS.gd");
 
 #
 #if not TestPackageAvailability("viz", "0.2.5")=fail then 

--- a/read.g
+++ b/read.g
@@ -1,10 +1,10 @@
-ReadPackage("intpic/gap/splash_from_Viz.g");
-ReadPackage("intpic/gap/ip_display.gi");
-ReadPackage("intpic/gap/ip_colors.gi");
-ReadPackage("intpic/gap/ip_tikz.gi");
-ReadPackage("intpic/gap/ip_dot.gi");
-ReadPackage("intpic/gap/ip_utils.gi");
-ReadPackage("intpic/gap/ip_tables.gi");
-ReadPackage("intpic/gap/ip_routines_for_NS.gi");
+ReadPackage("intpic", "gap/splash_from_Viz.g");
+ReadPackage("intpic", "gap/ip_display.gi");
+ReadPackage("intpic", "gap/ip_colors.gi");
+ReadPackage("intpic", "gap/ip_tikz.gi");
+ReadPackage("intpic", "gap/ip_dot.gi");
+ReadPackage("intpic", "gap/ip_utils.gi");
+ReadPackage("intpic", "gap/ip_tables.gi");
+ReadPackage("intpic", "gap/ip_routines_for_NS.gi");
 
 


### PR DESCRIPTION
The one argument form is not recommended, as it just has to split
the string into two anyway, and the input looks like a path, but
it isn't really, as the first part is a pacakge name, not a
directory name...
